### PR TITLE
reload-client.js with cross domain support

### DIFF
--- a/src/assets/reload-client.js
+++ b/src/assets/reload-client.js
@@ -1,5 +1,10 @@
 (function() {
-  var socket = io.connect();
+  var scripts = document.getElementsByTagName("scripts");
+  var socket = io.connect(
+    (function() { for(var i=0;i<scripts.length;i++) { if(scripts[i].src && scripts[i].src.indexOf("/socket.io.js"))
+      return (/^([^#]*?:\/\/.*?)(\/.*)$/.exec(scripts[i].src) || [])[1]
+    } })()
+  );
   socket.on('page',       reloadPage)
         .on('css',        reloadCss)
         .on('reconnect',  reloadPage);


### PR DESCRIPTION
Added script source lookup, so mimosa reload/socket.io works cross domain. The added script finds the script tag including /socket.io.js and takes the proctol, hostname and address. It falls back to undefined, which socket.io treats as document host.
