### PR TITLE
fixed misspelling of script tag

### DIFF
--- a/src/assets/reload-client.js
+++ b/src/assets/reload-client.js
@@ -1,5 +1,5 @@
 (function() {
-  var scripts = document.getElementsByTagName("scripts");
+  var scripts = document.getElementsByTagName("script");
   var socket = io.connect(
     (function() { for(var i=0;i<scripts.length;i++) { if(scripts[i].src && scripts[i].src.indexOf("/socket.io.js"))
       return (/^([^#]*?:\/\/.*?)(\/.*)$/.exec(scripts[i].src) || [])[1];


### PR DESCRIPTION
Fixed misspelling of script tag, which lead to not finding correct socket.io url.

I'm sorry that I didn't got that error out of the way before making pull request.
