### PR TITLE
Refresh css when watching additional directories

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,8 +71,14 @@ _setupDirectoryWatch = function(dirsToWatch) {
     watcher = watch.watch(dirsToWatch, {
       persistent: true
     });
-    watcher.on('all', function() {
-      return _emit('page');
+    watcher.on('all', function(event, filePath) {
+      var ext;
+      ext = path.extname(filePath);
+      if (ext === '.css') {
+        return _emit('css');
+      } else {
+        return _emit('page');
+      }
     });
     return watcher.on('error', function(error) {});
   }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -64,7 +64,12 @@ _setupDirectoryWatch = (dirsToWatch) ->
 
     directoryWatchSetup = true
     watcher = watch.watch dirsToWatch, {persistent: true}
-    watcher.on 'all', -> _emit 'page'
+    watcher.on 'all', (event, filePath) ->
+      ext = path.extname(filepath)
+      if(ext == '.css')
+        _emit 'css'
+      else
+        _emit 'page'
     watcher.on 'error', (error) ->
       # Doing nothing at the moment, just need to trap error event
       # console.log("ERROR: ", error)


### PR DESCRIPTION
It would be nice if when using the additionalDirs option to watch other directories it would check to see if it's a css file and only refresh the css instead of a full page reload.
